### PR TITLE
Remove custom YCSB Snapshot from benchmarks tutorial

### DIFF
--- a/data/latency_benchmarks/workloada.yaml
+++ b/data/latency_benchmarks/workloada.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 300 QPS/VM (1,500 QPS / Spanner Node)
       ycsb_run_parameters: target=300,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/latency_benchmarks/workloadb.yaml
+++ b/data/latency_benchmarks/workloadb.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 720 QPS/VM (3,600 QPS / Spanner Node)
       ycsb_run_parameters: target=720,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/latency_benchmarks/workloadc.yaml
+++ b/data/latency_benchmarks/workloadc.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 1,000 QPS/VM (5,000 QPS / Spanner Node)
       ycsb_run_parameters: target=1000,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/latency_benchmarks/workloadx.yaml
+++ b/data/latency_benchmarks/workloadx.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 220 QPS/VM (1,100 QPS / Spanner Node)
       ycsb_run_parameters: target=220,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/throughput_benchmarks/workloada.yaml
+++ b/data/throughput_benchmarks/workloada.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 770 QPS/VM (3,850 QPS / Spanner Node)
       ycsb_run_parameters: target=770,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/throughput_benchmarks/workloadb.yaml
+++ b/data/throughput_benchmarks/workloadb.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 1,610 QPS/VM (8,050 QPS / Spanner Node)
       ycsb_run_parameters: target=1610,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/throughput_benchmarks/workloadc.yaml
+++ b/data/throughput_benchmarks/workloadc.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 2,200 QPS/VM (1,100 QPS / Spanner Node)
       ycsb_run_parameters: target=2200,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/throughput_benchmarks/workloadx.yaml
+++ b/data/throughput_benchmarks/workloadx.yaml
@@ -46,9 +46,5 @@ benchmarks:
       # Target 800 QPS/VM (4,000 QPS / Spanner Node)
       ycsb_run_parameters: target=800,requestdistribution=zipfian,dataintegrity=True
 
-      # Custom YCSB tar to use Spanner Java Client v2.0.1
-      ycsb_tar_url: https://storage.googleapis.com/externally_shared_files/ycsb-0.18.0-SNAPSHOT.tar.gz
-      ycsb_version: 0.18.0-SNAPSHOT
-
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram


### PR DESCRIPTION
The official YCSB repo is now on Spanner Java Client v2.0.1, so we no longer need this custom version.