### PR TITLE
Change readmode on workloadc to 'read'

### DIFF
--- a/data/throughput_benchmarks/workloadc.yaml
+++ b/data/throughput_benchmarks/workloadc.yaml
@@ -19,6 +19,7 @@ benchmarks:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-west1
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
       # GCE Provisioning: 10 In-Region VMs per Spanner Node.
       ycsb_client_vms: 30


### PR DESCRIPTION
By default the Readmode on spanner ycsb is 'query'. this would mean that for every READ operation , a SQL select query is constructed and then the DML is executed on spanner via a transaction.
'read' will use the spanner's dbclient.singleuse client to execute point reads on the primary key 