### PR TITLE
Change workload on workloadc to 'read'

### DIFF
--- a/data/throughput_benchmarks/workloadc.yaml
+++ b/data/throughput_benchmarks/workloadc.yaml
@@ -19,6 +19,7 @@ benchmarks:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-west1
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
       # GCE Provisioning: 10 In-Region VMs per Spanner Node.
       ycsb_client_vms: 30


### PR DESCRIPTION
Default READ option in ycsb is 'query' which constructs an SQL 'select' statement and executes the read in the transaction.
changing it to 'read' mode will use the spanner library's dbclient.singleuse method to do point reads on the primary key which is more performant