### PR TITLE
Change readmode on benchmarks to 'read'

### DIFF
--- a/data/latency_benchmarks/workloada.yaml
+++ b/data/latency_benchmarks/workloada.yaml
@@ -19,6 +19,7 @@ benchmarks:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-west1
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
       # GCE Provisioning: 5 In-Region VMs per Spanner Node
       ycsb_client_vms: 15

--- a/data/latency_benchmarks/workloadb.yaml
+++ b/data/latency_benchmarks/workloadb.yaml
@@ -19,6 +19,7 @@ benchmarks:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-west1
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
       # GCE Provisioning: 5 In-Region VMs per Spanner Node
       ycsb_client_vms: 15

--- a/data/latency_benchmarks/workloadc.yaml
+++ b/data/latency_benchmarks/workloadc.yaml
@@ -19,6 +19,7 @@ benchmarks:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-west1
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
       # GCE Provisioning: 5 In-Region VMs per Spanner Node
       ycsb_client_vms: 15

--- a/data/throughput_benchmarks/workloada.yaml
+++ b/data/throughput_benchmarks/workloada.yaml
@@ -19,6 +19,7 @@ benchmarks:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-west1
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
       # GCE Provisioning: 5 In-Region VMs per Spanner Node
       ycsb_client_vms: 15

--- a/data/throughput_benchmarks/workloadb.yaml
+++ b/data/throughput_benchmarks/workloadb.yaml
@@ -19,6 +19,7 @@ benchmarks:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-west1
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
       # GCE Provisioning: 5 In-Region VMs per Spanner Node
       ycsb_client_vms: 15


### PR DESCRIPTION
'Read' mode is more performant than query mode for point reads since query will require constructing query plan etc.