### PR TITLE
Update spanner's benchmark files

### DIFF
--- a/data/recommended_utilization_benchmarks/readWrite_80_20.yaml
+++ b/data/recommended_utilization_benchmarks/readWrite_80_20.yaml
@@ -40,14 +40,14 @@ benchmarks:
       ycsb_sleep_after_load_in_sec: 3600
 
       # Execute workload for 30 minutes
-      ycsb_workload_files: workloadb
+      ycsb_workload_files: workloadb # This workload file will be overriden by explicit params in ycsb_run_parameters for this benchmark
       ycsb_timelimit: 1800
       ycsb_operation_count: 2000000000 # Opcount high so we hit timelimit
       ycsb_threads_per_client: '25'
 
-      # Target 708 QPS/VM (5900 QPS / Spanner Node)
+      # Target 624 QPS/VM (5200 QPS / Spanner Node)
       # Workload parameters specified here (80/20 Read/Write)
-      ycsb_run_parameters: target=708,requestdistribution=zipfian,dataintegrity=True,readproportion=0.8,updateproportion=0.2,scanproportion=0,insertproportion=0
+      ycsb_run_parameters: target=624,requestdistribution=zipfian,dataintegrity=True,readproportion=0.8,updateproportion=0.2,scanproportion=0,insertproportion=0
 
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/recommended_utilization_benchmarks/workloadc.yaml
+++ b/data/recommended_utilization_benchmarks/workloadc.yaml
@@ -44,9 +44,9 @@ benchmarks:
       ycsb_operation_count: 2000000000 # Opcount high so we hit timelimit
       ycsb_threads_per_client: '25'
 
-      # Target 1800 QPS/VM (15000 QPS / Spanner Node)
+      # Target 1500 QPS/VM (12500 QPS / Spanner Node)
       # Workload parameters specified here
-      ycsb_run_parameters: target=1800,requestdistribution=zipfian,dataintegrity=True,readproportion=1,updateproportion=0,scanproportion=0,insertproportion=0
+      ycsb_run_parameters: target=1500,requestdistribution=zipfian,dataintegrity=True,readproportion=1,updateproportion=0,scanproportion=0,insertproportion=0
 
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/throughput_benchmarks/readWrite_80_20.yaml
+++ b/data/throughput_benchmarks/readWrite_80_20.yaml
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Spanner throughput benchmark PKB configuration (workloadx)
+# Spanner throughput benchmark PKB configuration for read/Write (80/20) workload.
+# This is a modified workloadb configuration to use a split of 80/20 for read/write.
 benchmarks:
 - cloud_spanner_ycsb:
     flags:
       # Spanner Provisioning
       cloud_spanner_config: regional-us-east4
       cloud_spanner_nodes: 3
+      cloud_spanner_ycsb_readmode: 'read'
 
-      # GCE Provisioning: 15 In-Region VMs per Spanner Node
-      ycsb_client_vms: 15
+      # GCE Provisioning: 40 In-Region VMs per Spanner Node
+      ycsb_client_vms: 40
       machine_type: n1-standard-2
       gce_network_name: default
       zone: us-east4-a
@@ -37,14 +39,15 @@ benchmarks:
       # Sleep 1hr between Load and Run phases
       ycsb_sleep_after_load_in_sec: 3600
 
-      # Execute workloadx for 30minutes
-      ycsb_workload_files: workloadx
+      # Execute workload for 30 minutes
+      ycsb_workload_files: workloadb # This workload file will be overriden by explicit params in ycsb_run_parameters for this benchmark
       ycsb_timelimit: 1800
       ycsb_operation_count: 2000000000 # Opcount high so we hit timelimit
       ycsb_threads_per_client: '25'
 
-      # Target 960 QPS/VM (4,800 QPS / Spanner Node)
-      ycsb_run_parameters: target=960,requestdistribution=zipfian,dataintegrity=True
+      # Target 885 QPS/VM (11800 QPS / Spanner Node)
+      # Workload parameters specified here (80/20 Read/Write)
+      ycsb_run_parameters: target=885,requestdistribution=zipfian,dataintegrity=True,readproportion=0.8,updateproportion=0.2,scanproportion=0,insertproportion=0
 
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram

--- a/data/throughput_benchmarks/workloadc.yaml
+++ b/data/throughput_benchmarks/workloadc.yaml
@@ -21,8 +21,8 @@ benchmarks:
       cloud_spanner_nodes: 3
       cloud_spanner_ycsb_readmode: 'read'
 
-      # GCE Provisioning: 10 In-Region VMs per Spanner Node.
-      ycsb_client_vms: 45
+      # GCE Provisioning: 36 In-Region VMs per Spanner Node.
+      ycsb_client_vms: 36
       machine_type: n1-standard-2
       gce_network_name: default
       zone: us-east4-a
@@ -44,8 +44,8 @@ benchmarks:
       ycsb_operation_count: 2147483640 # Opcount high so we hit timelimit
       ycsb_threads_per_client: '32'
 
-      # Target 1800 QPS/VM ( 27,000 QPS / Spanner Node)
-      ycsb_run_parameters: target=1800,requestdistribution=zipfian,dataintegrity=True
+      # Target 1875 QPS/VM ( 22,500 QPS / Spanner Node)
+      ycsb_run_parameters: target=1875,requestdistribution=zipfian,dataintegrity=True
 
       # Output the results as a histogram
       ycsb_measurement_type: hdrhistogram


### PR DESCRIPTION
1. Provide new benchmarks for ReadWrite_80_20 split workload
2. Update spanner's recommended utilization benchmarks' workload files.
3. Update the documentation.